### PR TITLE
Fix locale code for QR payment

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,7 @@
                 confirmationMessage.innerHTML = `Thank you, <span class="font-semibold">${fullName}</span>! Your registration for the <span class="font-semibold">${ticketNameDisplay}</span> has been received.`;
                 
                 amountDueBank.textContent = `₱${displayPrice.toLocaleString('en-PH', {minimumFractionDigits: 2, maximumFractionDigits: 2})} (Inclusive of EWT & VAT)`;
-                amountDueQR.textContent = `₱${displayPrice.toLocaleString('en-ph', {minimumFractionDigits: 2, maximumFractionDigits: 2})} (Inclusive of EWT & VAT)`;
+                amountDueQR.textContent = `₱${displayPrice.toLocaleString('en-PH', {minimumFractionDigits: 2, maximumFractionDigits: 2})} (Inclusive of EWT & VAT)`;
                 qrCodeImage.src = qrImageSrc;
 
                 paymentInstructions.classList.remove('hidden-element');


### PR DESCRIPTION
## Summary
- fix locale code for payment amount formatting so currency renders correctly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6869ce2cae30832e8b15f61fd5efb07e